### PR TITLE
Make MochaWatch an EventEmitter and tie output messages to events.

### DIFF
--- a/lib/MochaWatch.js
+++ b/lib/MochaWatch.js
@@ -1,10 +1,13 @@
 const chokidar = require("chokidar");
-const findTestFilesToRun = require("./findTestFilesToRun");
-const findFilesMochaWouldRun = require("./findFilesMochaWouldRun");
+const EventEmitter = require("events").EventEmitter;
 const { resolve } = require("path");
 
-module.exports = class MochaWatch {
+const findTestFilesToRun = require("./findTestFilesToRun");
+const findFilesMochaWouldRun = require("./findFilesMochaWouldRun");
+
+module.exports = class MochaWatch extends EventEmitter {
   constructor(cwd, gitClient, sourceGraph, mochaWorker, program) {
+    super();
     this.cwd = cwd;
     this.gitClient = gitClient;
     this.sourceGraph = sourceGraph;
@@ -18,9 +21,7 @@ module.exports = class MochaWatch {
   }
 
   debug(...args) {
-    if (process.env.DEBUG) {
-      console.log(...args);
-    }
+    this.emit("debug", ...args);
   }
 
   init() {
@@ -115,6 +116,10 @@ module.exports = class MochaWatch {
       this.gitClient
     );
 
-    await this.mochaWorker.runTests(relatedTestFiles);
+    this.emit("run begin");
+
+    const result = await this.mochaWorker.runTests(relatedTestFiles);
+
+    this.emit("run complete", result);
   }
 };

--- a/lib/MochaWorker.js
+++ b/lib/MochaWorker.js
@@ -21,15 +21,8 @@ module.exports = class MochaWorker {
       throw new Error("Already running.");
     }
 
-    if (!process.env.DEBUG) {
-      process.stdout.write("\x1B[2J");
-    }
-
-    console.log("Running tests at", new Date());
-
     if (testFilePaths.length === 0) {
-      console.log("\nNo tests to run.");
-      return;
+      return { exitCode: 0, testDuration: -1 };
     }
 
     return new Promise((resolve, reject) => {
@@ -54,10 +47,8 @@ module.exports = class MochaWorker {
 
         worker.on("close", exitCode => {
           this.state = "stopped";
-          if (process.env.DEBUG) {
-            console.log("%sms", Date.now() - startTime);
-          }
-          return resolve({ exitCode });
+          const testDuration = Date.now() - startTime;
+          return resolve({ exitCode, testDuration });
         });
       } catch (e) {
         this.state = "stopped";

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -34,6 +34,30 @@ module.exports = async function cli(cwd) {
     }
   });
 
+  mochaWatch.on("debug", () => {
+    if (process.env.DEBUG) {
+      console.log(...args);
+    }
+  });
+
+  mochaWatch.on("run begin", () => {
+    if (!process.env.DEBUG) {
+      process.stdout.write("\x1B[2J");
+    }
+
+    console.log("Running tests at", new Date());
+  });
+
+  mochaWatch.on("run complete", result => {
+    const { testDuration } = result;
+
+    if (testDuration === -1) {
+      console.log("\nNo tests to run.");
+    } else if (process.env.DEBUG) {
+      console.log("%sms", result.testDuration);
+    }
+  });
+
   process.on("SIGINT", () => {
     mochaWatch.stop();
     process.stdin.end("\n");


### PR DESCRIPTION
This consolidates all checking of process.env.DEBUG and output of
messages in the cli file. It all provides specific named events
that correspond to "begin" and "complete" of test runs.