### PR TITLE
Add discovered files to a queue that is then flushed at test run time.

### DIFF
--- a/lib/MochaWatch.js
+++ b/lib/MochaWatch.js
@@ -17,6 +17,7 @@ module.exports = class MochaWatch extends EventEmitter {
     this.state = "stopped";
 
     this.watcher = null;
+    this.watcherQueuedFiles = [];
     this.testTimer = null;
   }
 
@@ -44,6 +45,10 @@ module.exports = class MochaWatch extends EventEmitter {
     this.watcher.close();
   }
 
+  queueFile(path) {
+    this.watcherQueuedFiles.push(path);
+  }
+
   queueTestRun() {
     if (this.state === "stopped") {
       return;
@@ -64,15 +69,7 @@ module.exports = class MochaWatch extends EventEmitter {
     this.debug("added", path);
     path = resolve(this.cwd, path);
 
-    const testFiles = await findFilesMochaWouldRun(this.program);
-
-    // If the added file is a test file we need to repopulate the sourceGraph,
-    // otherwise we can just add the file.
-    if (testFiles.includes(path)) {
-      await this.sourceGraph.populate(testFiles);
-    } else {
-      await this.sourceGraph.addFileFromPath(path);
-    }
+    this.queueFile(path);
 
     this.queueTestRun();
   }
@@ -83,13 +80,13 @@ module.exports = class MochaWatch extends EventEmitter {
     }
     this.debug("changed", path);
     path = resolve(this.cwd, path);
+
     const file = this.sourceGraph.query({ type: "file", path });
-
-    if (!file) {
-      throw new Error(`Change event on unknown file "${path}".`);
+    if (file) {
+      await file.reload();
+    } else {
+      this.queueFile(path);
     }
-
-    await file.reload();
 
     this.queueTestRun();
   }
@@ -110,7 +107,23 @@ module.exports = class MochaWatch extends EventEmitter {
     this.queueTestRun();
   }
 
+  async flushQueuedFiles() {
+    const testFiles = await findFilesMochaWouldRun(this.program);
+    this.sourceGraph.setTestFilePaths(testFiles);
+
+    const filesToProcess = this.watcherQueuedFiles;
+    this.watcherQueuedFiles = []; // record the queue was processed
+
+    this.debug("flushQueuedFiles", ...filesToProcess);
+
+    for (const path of filesToProcess) {
+      await this.sourceGraph.addFileFromPath(path);
+    }
+  }
+
   async runTests() {
+    await this.flushQueuedFiles();
+
     const relatedTestFiles = await findTestFilesToRun(
       this.sourceGraph,
       this.gitClient

--- a/lib/SourceGraph/SourceGraph.js
+++ b/lib/SourceGraph/SourceGraph.js
@@ -8,12 +8,16 @@ module.exports = class SourceGraph {
     this.testFilePaths = [];
   }
 
-  async populate(testFiles) {
+  setTestFilePaths(testFiles) {
     if (!Array.isArray(testFiles)) {
       throw new Error("You must pass in a list of files to populate from.");
     }
 
     this.testFilePaths = testFiles;
+  }
+
+  async populate(testFiles) {
+    this.setTestFilePaths(testFiles);
 
     for (const filePath of this.testFilePaths) {
       await this.addFileFromPath(filePath);


### PR DESCRIPTION
As files are discovered the test timer is pushed back. In addition
to doing this, this commit also postpones processing added files
until we come to run the tests.

What this enables is only recalculating the files that would be run
by mocha once, apply this update wholesale to the SourceGraph and
then allow addFileFromPath() to take care of the is testFile check.

Closes https://github.com/gustavnikolaj/imocha/issues/20.