### PR TITLE
Enable JSX syntax if the babel plugin is present

### DIFF
--- a/lib/findRelationsInSourceCode.js
+++ b/lib/findRelationsInSourceCode.js
@@ -24,7 +24,9 @@ module.exports = function findRelationsInSourceCode(source) {
     // https://babeljs.io/docs/en/next/babel-parser.html#plugins
     plugins: [
       // Enable objectRestSpread plugin.
-      "objectRestSpread"
+      "objectRestSpread",
+      // Enable the JSX syntax plugin
+      "jsx"
     ]
   });
 

--- a/test/findRelationsInSourceCode.spec.js
+++ b/test/findRelationsInSourceCode.spec.js
@@ -86,4 +86,21 @@ describe("findRelationsInSourceCode", () => {
       []
     );
   });
+
+  it("should support jsx syntax", () => {
+    expect(
+      findRelationsInSourceCode(`
+        import User from './User'
+        export const UserDetails = ({ avatar, email, name }) => (
+          <div className='user-details'>
+            <Avatar className="user-avatar" src={avatar} />
+            <span className="user-name">{name}</span>
+            <span className="user-email">{email}</span>
+          </div>
+        );
+      `),
+      "to equal",
+      ["./User"]
+    );
+  });
 });


### PR DESCRIPTION
This should be safe as babel parser supports JSX out of the box.
https://babeljs.io/docs/en/babel-parser