### PR TITLE
Remove async/await from the codebase

### DIFF
--- a/bin/imocha
+++ b/bin/imocha
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-const asyncMainWrap = require("@gustavnikolaj/async-main-wrap");
 const main = require("../lib/cli");
 
-asyncMainWrap(main)(process.cwd(), process.argv.slice(2));
+main(process.cwd(), process.argv.slice(2));

--- a/lib/MochaWatch.js
+++ b/lib/MochaWatch.js
@@ -50,61 +50,59 @@ module.exports = class MochaWatch extends EventEmitter {
     });
   }
 
-  async findTestFilesToRun() {
-    let dirtyFiles;
-
-    try {
-      dirtyFiles = await listDirtyFilesInGitRepo(this.cwd);
-    } catch (e) {
-      if (e.code === "IMOCHA_NO_GIT_REPO") {
-        // Consider all test files dirty if we are not in a git repo. This will
-        // result in executing all test files whenever any javascript file in
-        // the folder changes.
-        dirtyFiles = findFilesMochaWouldRun(this.mochaOpts);
-      } else {
-        throw e;
-      }
-    }
-
-    const dirtySourceFiles = dirtyFiles.reduce((files, path) => {
-      const result = this.sourceGraph.query({ type: "file", path });
-
-      if (result) {
-        files.push(path);
-      }
-
-      return files;
-    }, []);
-
-    const filesToProcess = new Set(dirtySourceFiles);
-    const processedFiles = new Set();
-    const relatedTestFiles = new Set();
-
-    while (filesToProcess.size > 0) {
-      for (const path of filesToProcess.keys()) {
-        filesToProcess.delete(path);
-        if (processedFiles.has(path)) {
-          continue;
+  findTestFilesToRun() {
+    return listDirtyFilesInGitRepo(this.cwd)
+      .catch(err => {
+        if (err.code === "IMOCHA_NO_GIT_REPO") {
+          // Consider all test files dirty if we are not in a git repo. This will
+          // result in executing all test files whenever any javascript file in
+          // the folder changes.
+          return findFilesMochaWouldRun(this.mochaOpts);
+        } else {
+          throw err;
         }
-        processedFiles.add(path);
+      })
+      .then(dirtyFiles => {
+        const dirtySourceFiles = dirtyFiles.reduce((files, path) => {
+          const result = this.sourceGraph.query({ type: "file", path });
 
-        const sourceFile = this.sourceGraph.query({ type: "file", path });
+          if (result) {
+            files.push(path);
+          }
 
-        if (sourceFile.isTestFile) {
-          relatedTestFiles.add(path);
-          // We don't need to look for relations to the source files. If they are
-          // changed they need to be run.
-          // XXX: Don't skip this - it might be that the file was matched as a test file by default.
-          // continue;
+          return files;
+        }, []);
+
+        const filesToProcess = new Set(dirtySourceFiles);
+        const processedFiles = new Set();
+        const relatedTestFiles = new Set();
+
+        while (filesToProcess.size > 0) {
+          for (const path of filesToProcess.keys()) {
+            filesToProcess.delete(path);
+            if (processedFiles.has(path)) {
+              continue;
+            }
+            processedFiles.add(path);
+
+            const sourceFile = this.sourceGraph.query({ type: "file", path });
+
+            if (sourceFile.isTestFile) {
+              relatedTestFiles.add(path);
+              // We don't need to look for relations to the source files. If they are
+              // changed they need to be run.
+              // XXX: Don't skip this - it might be that the file was matched as a test file by default.
+              // continue;
+            }
+
+            for (const { from: relatedFile } of sourceFile.incomingRelations) {
+              filesToProcess.add(relatedFile);
+            }
+          }
         }
 
-        for (const { from: relatedFile } of sourceFile.incomingRelations) {
-          filesToProcess.add(relatedFile);
-        }
-      }
-    }
-
-    return [...relatedTestFiles];
+        return [...relatedTestFiles];
+      });
   }
 
   stop() {
@@ -128,7 +126,7 @@ module.exports = class MochaWatch extends EventEmitter {
     this.testTimer = setTimeout(() => this.runTests(), 500);
   }
 
-  async fileAdded(path) {
+  fileAdded(path) {
     if (this.state === "stopped") {
       return;
     }
@@ -140,7 +138,7 @@ module.exports = class MochaWatch extends EventEmitter {
     this.queueTestRun();
   }
 
-  async fileChanged(path) {
+  fileChanged(path) {
     if (this.state === "stopped") {
       return;
     }
@@ -149,7 +147,7 @@ module.exports = class MochaWatch extends EventEmitter {
 
     const file = this.sourceGraph.query({ type: "file", path });
     if (file) {
-      await file.reload();
+      file.reload();
     } else {
       this.queueFile(path);
     }
@@ -157,7 +155,7 @@ module.exports = class MochaWatch extends EventEmitter {
     this.queueTestRun();
   }
 
-  async fileUnlink(path) {
+  fileUnlink(path) {
     if (this.state === "stopped") {
       return;
     }
@@ -173,8 +171,8 @@ module.exports = class MochaWatch extends EventEmitter {
     this.queueTestRun();
   }
 
-  async flushQueuedFiles() {
-    const testFiles = await findFilesMochaWouldRun(this.mochaOpts);
+  flushQueuedFiles() {
+    const testFiles = findFilesMochaWouldRun(this.mochaOpts);
     this.sourceGraph.setTestFilePaths(testFiles);
 
     const filesToProcess = this.watcherQueuedFiles;
@@ -182,20 +180,20 @@ module.exports = class MochaWatch extends EventEmitter {
 
     this.debug("flushQueuedFiles", ...filesToProcess);
 
-    for (const path of filesToProcess) {
-      await this.sourceGraph.addFileFromPath(path);
-    }
+    return Promise.all(
+      filesToProcess.map(path => this.sourceGraph.addFileFromPath(path))
+    );
   }
 
-  async runTests() {
-    await this.flushQueuedFiles();
-
-    const testFilesToRun = await this.findTestFilesToRun();
-
-    this.emit("run begin");
-
-    const result = await this.mochaWorker.runTests(testFilesToRun);
-
-    this.emit("run complete", result);
+  runTests() {
+    return this.flushQueuedFiles()
+      .then(() => this.findTestFilesToRun())
+      .then(testFilesToRun => {
+        this.emit("run begin");
+        return this.mochaWorker.runTests(testFilesToRun);
+      })
+      .then(result => {
+        this.emit("run complete", result);
+      });
   }
 };

--- a/lib/MochaWatch.js
+++ b/lib/MochaWatch.js
@@ -147,12 +147,11 @@ module.exports = class MochaWatch extends EventEmitter {
 
     const file = this.sourceGraph.query({ type: "file", path });
     if (file) {
-      file.reload();
+      file.reload().then(() => this.queueTestRun());
     } else {
       this.queueFile(path);
+      this.queueTestRun();
     }
-
-    this.queueTestRun();
   }
 
   fileUnlink(path) {

--- a/lib/MochaWatch.js
+++ b/lib/MochaWatch.js
@@ -147,10 +147,11 @@ module.exports = class MochaWatch extends EventEmitter {
 
     const file = this.sourceGraph.query({ type: "file", path });
     if (file) {
-      file.reload().then(() => this.queueTestRun());
+      return file.reload().then(() => this.queueTestRun());
     } else {
       this.queueFile(path);
       this.queueTestRun();
+      return Promise.resolve();
     }
   }
 

--- a/lib/MochaWorker.js
+++ b/lib/MochaWorker.js
@@ -19,13 +19,13 @@ module.exports = class MochaWorker {
     return args.concat(testFilePaths);
   }
 
-  async runTests(testFilePaths) {
+  runTests(testFilePaths) {
     if (this.state !== "stopped") {
-      throw new Error("Already running.");
+      return Promise.reject(new Error("Already running."));
     }
 
     if (testFilePaths.length === 0) {
-      return { exitCode: 0, testDuration: -1 };
+      return Promise.resolve({ exitCode: 0, testDuration: -1 });
     }
 
     return new Promise((resolve, reject) => {

--- a/lib/SourceGraph/File.js
+++ b/lib/SourceGraph/File.js
@@ -25,29 +25,31 @@ module.exports = class File {
     return this.sourceGraph.query({ type: "relations", to: this.path });
   }
 
-  async load() {
-    this.fileContents = await readFile(this.path, "utf-8");
-    this.loaded = true;
-    await this.findRelations();
+  load() {
+    return readFile(this.path, "utf-8").then(content => {
+      this.fileContents = content;
+      this.loaded = true;
+      return this.findRelations();
+    });
   }
 
-  async reload() {
+  reload() {
     this.relations = [];
-    await this.load();
+    return this.load();
   }
 
   remove() {
     this.sourceGraph.removeFile(this);
   }
 
-  async findRelations() {
+  findRelations() {
     if (!this.loaded) {
-      throw new Error("Cannot find relations in unloaded File.");
+      return Promise.reject(Error("Cannot find relations in unloaded File."));
     }
 
     if (path.extname(this.path) !== ".js") {
       // Skip scanning for relations in non .js files.
-      return;
+      return Promise.resolve();
     }
 
     let relations;
@@ -61,29 +63,36 @@ module.exports = class File {
         ...remainingErrorLines
       ].join("\n");
 
-      throw e;
+      return Promise.reject(e);
     }
+
     const dirName = path.dirname(this.path);
 
-    for (const relation of relations) {
-      if (isNpmPackage(relation)) {
-        // TODO: Look for changes in package.json, package-lock.json or yarn.lock
-        continue;
-      }
-      const dest = await resolveRequire(dirName, relation);
-      if (dest) {
-        await this.addRelation(dest);
-      }
-    }
+    return Promise.all(
+      relations.map(relation => {
+        if (isNpmPackage(relation)) {
+          // TODO: Look for changes in package.json, package-lock.json or yarn.lock
+          return;
+        }
+
+        const dest = resolveRequire(dirName, relation);
+        if (dest) {
+          return this.addRelation(dest);
+        }
+      })
+    );
   }
 
-  async addRelation(to) {
+  addRelation(to) {
     const relation = new Relation(this.path, to);
 
-    if (!this.sourceGraph.query({ type: "file", path: to })) {
-      await this.sourceGraph.addFileFromPath(to);
+    if (this.sourceGraph.query({ type: "file", path: to })) {
+      this.relations.push(relation);
+      return Promise.resolve();
+    } else {
+      return this.sourceGraph.addFileFromPath(to).then(() => {
+        this.relations.push(relation);
+      });
     }
-
-    this.relations.push(relation);
   }
 };

--- a/lib/SourceGraph/SourceGraph.js
+++ b/lib/SourceGraph/SourceGraph.js
@@ -16,22 +16,22 @@ module.exports = class SourceGraph {
     this.testFilePaths = testFiles;
   }
 
-  async populate(testFiles) {
+  populate(testFiles) {
     this.setTestFilePaths(testFiles);
 
-    for (const filePath of this.testFilePaths) {
-      await this.addFileFromPath(filePath);
-    }
+    return Promise.all(
+      this.testFilePaths.map(filePath => this.addFileFromPath(filePath))
+    );
   }
 
-  async addFileFromPath(filePath) {
+  addFileFromPath(filePath) {
     const file = this.testFilePaths.includes(filePath)
       ? new TestFile(filePath, this)
       : new File(filePath, this);
 
     this.files.push(file);
 
-    await file.load();
+    return file.load();
   }
 
   removeFile(fileForRemoval) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -3,7 +3,7 @@ const MochaWorker = require("./MochaWorker");
 const MochaWatch = require("./MochaWatch");
 const { loadOptions } = require("mocha/lib/cli/options");
 
-module.exports = async function cli(cwd, args) {
+module.exports = function cli(cwd, args) {
   const mochaOpts = loadOptions(args);
   const sourceGraph = new SourceGraph(cwd);
   const mochaWorker = new MochaWorker(mochaOpts, args);

--- a/lib/resolveRequire.js
+++ b/lib/resolveRequire.js
@@ -1,7 +1,7 @@
 const isNpmPackage = require("./isNpmPackage");
 const resolveFrom = require("resolve-from");
 
-module.exports = async function resolveRequire(context, requiredPath) {
+module.exports = function resolveRequire(context, requiredPath) {
   if (isNpmPackage(requiredPath)) {
     throw new Error("Module resolution not yet implemented");
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -111,11 +111,6 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@gustavnikolaj/async-main-wrap": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@gustavnikolaj/async-main-wrap/-/async-main-wrap-3.0.1.tgz",
-      "integrity": "sha512-FHh1Tz5Jk5xJphcYpFUMsxCTO+XbgQyCorlbztqBsYRnu5hmuoV/0Q+dJlcOtQCG6cJ5/EHX+VrSsoLBoaTJvQ=="
-    },
     "@gustavnikolaj/find-relations-in-js": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@gustavnikolaj/find-relations-in-js/-/find-relations-in-js-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "unexpected": "^11.6.1"
   },
   "dependencies": {
-    "@gustavnikolaj/async-main-wrap": "^3.0.1",
     "@gustavnikolaj/find-relations-in-js": "^1.2.0",
     "chokidar": "^3.0.1",
     "minimatch": "3.0.4",

--- a/test/MochaWatch.spec.js
+++ b/test/MochaWatch.spec.js
@@ -68,7 +68,8 @@ describe("MochaWatch", () => {
     it("should reload an existing file", () => {
       const reloadCalls = [];
       const fakeFile = {
-        reload: (...args) => reloadCalls.push(args)
+        reload: (...args) =>
+          Promise.resolve().then(() => reloadCalls.push(args))
       };
       const sourceGraph = createMockSourceGraph({
         query: () => fakeFile
@@ -76,11 +77,14 @@ describe("MochaWatch", () => {
       const mochaWatch = new MochaWatch(null, sourceGraph);
       mochaWatch.state = "ready";
 
-      mochaWatch.fileChanged("/path/to/file");
-
-      expect(reloadCalls, "not to be empty");
-      expect(mochaWatch.watcherQueuedFiles, "to be empty");
-      clearTimeout(mochaWatch.testTimer);
+      return expect(
+        () => mochaWatch.fileChanged("/path/to/file"),
+        "to be fulfilled"
+      ).then(() => {
+        expect(reloadCalls, "not to be empty");
+        expect(mochaWatch.watcherQueuedFiles, "to be empty");
+        clearTimeout(mochaWatch.testTimer);
+      });
     });
 
     it("should queue a new file", () => {

--- a/test/MochaWatch.spec.js
+++ b/test/MochaWatch.spec.js
@@ -53,19 +53,19 @@ describe("MochaWatch", () => {
   });
 
   describe("#fileChanged", () => {
-    it('should ignore calls if "stopped"', async () => {
+    it('should ignore calls if "stopped"', () => {
       const mochaWatch = new MochaWatch();
       mochaWatch.state = "stopped";
 
       const calls = [];
       mochaWatch.queueFile = (...args) => calls.push(args);
 
-      await mochaWatch.fileChanged();
+      mochaWatch.fileChanged();
 
       expect(calls, "to be empty");
     });
 
-    it("should reload an existing file", async () => {
+    it("should reload an existing file", () => {
       const reloadCalls = [];
       const fakeFile = {
         reload: (...args) => reloadCalls.push(args)
@@ -76,19 +76,19 @@ describe("MochaWatch", () => {
       const mochaWatch = new MochaWatch(null, sourceGraph);
       mochaWatch.state = "ready";
 
-      await mochaWatch.fileChanged("/path/to/file");
+      mochaWatch.fileChanged("/path/to/file");
 
       expect(reloadCalls, "not to be empty");
       expect(mochaWatch.watcherQueuedFiles, "to be empty");
       clearTimeout(mochaWatch.testTimer);
     });
 
-    it("should queue a new file", async () => {
+    it("should queue a new file", () => {
       const sourceGraph = createMockSourceGraph();
       const mochaWatch = new MochaWatch(null, sourceGraph);
       mochaWatch.state = "ready";
 
-      await mochaWatch.fileChanged("/path/to/file");
+      mochaWatch.fileChanged("/path/to/file");
 
       expect(mochaWatch.watcherQueuedFiles, "to contain", "/path/to/file");
       clearTimeout(mochaWatch.testTimer);
@@ -96,19 +96,19 @@ describe("MochaWatch", () => {
   });
 
   describe("#fileUnlink", () => {
-    it('should ignore calls if "stopped"', async () => {
+    it('should ignore calls if "stopped"', () => {
       const mochaWatch = new MochaWatch();
       mochaWatch.state = "stopped";
 
       const calls = [];
       mochaWatch.queueFile = (...args) => calls.push(args);
 
-      await mochaWatch.fileUnlink();
+      mochaWatch.fileUnlink();
 
       expect(calls, "to be empty");
     });
 
-    it("should remove an existing file", async () => {
+    it("should remove an existing file", () => {
       const removeCalls = [];
       const fakeFile = {
         remove: (...args) => removeCalls.push(args)
@@ -119,7 +119,7 @@ describe("MochaWatch", () => {
       const mochaWatch = new MochaWatch(null, sourceGraph);
       mochaWatch.state = "ready";
 
-      await mochaWatch.fileUnlink("/path/to/file");
+      mochaWatch.fileUnlink("/path/to/file");
 
       expect(removeCalls, "not to be empty");
       expect(mochaWatch.watcherQueuedFiles, "to be empty");
@@ -128,7 +128,7 @@ describe("MochaWatch", () => {
   });
 
   describe("#flushQueuedFiles", () => {
-    it("should recalculate the files run by mocha", async () => {
+    it("should recalculate the files run by mocha", () => {
       const mochaOpts = {
         extension: ["js"]
       };
@@ -138,12 +138,15 @@ describe("MochaWatch", () => {
       });
       const mochaWatch = new MochaWatch(null, sourceGraph, null, mochaOpts);
 
-      await mochaWatch.flushQueuedFiles();
-
-      expect(setTestFilePathsCalls, "to have length", 1);
+      return expect(
+        () => mochaWatch.flushQueuedFiles(),
+        "to be fulfilled"
+      ).then(() => {
+        return expect(setTestFilePathsCalls, "to have length", 1);
+      });
     });
 
-    it("should process any queued files", async () => {
+    it("should process any queued files", () => {
       const mochaOpts = {
         extension: ["js"]
       };
@@ -158,14 +161,17 @@ describe("MochaWatch", () => {
         "/path/to/file3"
       ];
 
-      await mochaWatch.flushQueuedFiles();
-
-      expect(addFileFromPathCalls, "to equal", [
-        ["/path/to/file1"],
-        ["/path/to/file2"],
-        ["/path/to/file3"]
-      ]);
-      expect(mochaWatch.watcherQueuedFiles, "to be empty");
+      return expect(() => mochaWatch.flushQueuedFiles(), "to be fulfilled")
+        .then(() => {
+          return expect(addFileFromPathCalls, "to equal", [
+            ["/path/to/file1"],
+            ["/path/to/file2"],
+            ["/path/to/file3"]
+          ]);
+        })
+        .then(() => {
+          return expect(mochaWatch.watcherQueuedFiles, "to be empty");
+        });
     });
   });
 
@@ -217,21 +223,22 @@ describe("MochaWatch", () => {
   });
 
   describe("#runTests", () => {
-    it("should flush queued files", async () => {
+    it("should flush queued files", () => {
       const mochaWorker = createMockMochaWorker();
       const mochaWatch = new MochaWatch(null, null, mochaWorker);
       mochaWatch.state = "ready";
-      mochaWatch.findTestFilesToRun = () => [];
+      mochaWatch.findTestFilesToRun = () => Promise.resolve([]);
 
       const calls = [];
-      mochaWatch.flushQueuedFiles = (...args) => calls.push(args);
+      mochaWatch.flushQueuedFiles = (...args) =>
+        Promise.resolve().then(() => calls.push(args));
 
-      await mochaWatch.runTests();
-
-      expect(calls, "to have length", 1);
+      return expect(() => mochaWatch.runTests(), "to be fulfilled").then(() => {
+        return expect(calls, "to have length", 1);
+      });
     });
 
-    it("should trigger the mocha worker with found test files", async () => {
+    it("should trigger the mocha worker with found test files", () => {
       const calls = [];
       const mochaWorker = createMockMochaWorker({
         runTests: (...args) => calls.push(args)
@@ -239,17 +246,14 @@ describe("MochaWatch", () => {
       const mochaWatch = new MochaWatch(null, null, mochaWorker);
       mochaWatch.state = "ready";
       mochaWatch.flushQueuedFiles = () => Promise.resolve();
-      mochaWatch.findTestFilesToRun = () => [
-        "/path/to/file1",
-        "/path/to/file2",
-        "/path/to/file3"
-      ];
+      mochaWatch.findTestFilesToRun = () =>
+        Promise.resolve(["/path/to/file1", "/path/to/file2", "/path/to/file3"]);
 
-      await mochaWatch.runTests();
-
-      expect(calls, "to equal", [
-        [["/path/to/file1", "/path/to/file2", "/path/to/file3"]]
-      ]);
+      return expect(() => mochaWatch.runTests(), "to be fulfilled").then(() => {
+        return expect(calls, "to equal", [
+          [["/path/to/file1", "/path/to/file2", "/path/to/file3"]]
+        ]);
+      });
     });
   });
 });

--- a/test/SourceGraph.spec.js
+++ b/test/SourceGraph.spec.js
@@ -12,69 +12,101 @@ describe("SourceGraph", () => {
   });
 
   describe("fixtures", () => {
-    it("should load the simple fixture", async () => {
-      const fixturePath = resolveFixture("simple");
-      const sourceGraph = new SourceGraph(fixturePath);
+    describe("simple fixture", () => {
+      it("should load all three files", () => {
+        const fixturePath = resolveFixture("simple");
+        const sourceGraph = new SourceGraph(fixturePath);
 
-      // pass the list of test files mocha would run to populate
-      await sourceGraph.populate([
-        path.resolve(fixturePath, "test/bar.spec.js")
-      ]);
-
-      await expect(sourceGraph, "to satisfy", {
-        files: [
-          { path: path.resolve(fixturePath, "test/bar.spec.js") },
-          { path: path.resolve(fixturePath, "bar.js") },
-          { path: path.resolve(fixturePath, "foo.js") }
-        ]
+        return expect(
+          () =>
+            sourceGraph.populate([
+              path.resolve(fixturePath, "test/bar.spec.js")
+            ]),
+          "to be fulfilled"
+        ).then(() => {
+          expect(sourceGraph, "to satisfy", {
+            files: [
+              { path: path.resolve(fixturePath, "test/bar.spec.js") },
+              { path: path.resolve(fixturePath, "bar.js") },
+              { path: path.resolve(fixturePath, "foo.js") }
+            ]
+          });
+        });
       });
 
-      await expect(
-        sourceGraph.query({
-          type: "relations",
-          to: path.resolve(fixturePath, "foo.js")
-        }),
-        "to satisfy",
-        [
-          {
-            from: path.resolve(fixturePath, "bar.js"),
-            to: path.resolve(fixturePath, "foo.js")
-          }
-        ]
-      );
+      it("should find code depending on foo.js", () => {
+        const fixturePath = resolveFixture("simple");
+        const sourceGraph = new SourceGraph(fixturePath);
 
-      await expect(
-        sourceGraph.query({
-          type: "relations",
-          to: path.resolve(fixturePath, "bar.js")
-        }),
-        "to satisfy",
-        [
-          {
-            from: path.resolve(fixturePath, "test/bar.spec.js"),
-            to: path.resolve(fixturePath, "bar.js")
-          }
-        ]
-      );
+        return expect(
+          () =>
+            sourceGraph.populate([
+              path.resolve(fixturePath, "test/bar.spec.js")
+            ]),
+          "to be fulfilled"
+        ).then(() => {
+          expect(
+            sourceGraph.query({
+              type: "relations",
+              to: path.resolve(fixturePath, "foo.js")
+            }),
+            "to satisfy",
+            [
+              {
+                from: path.resolve(fixturePath, "bar.js"),
+                to: path.resolve(fixturePath, "foo.js")
+              }
+            ]
+          );
+        });
+      });
+      it("should find code depending on bar.js", () => {
+        const fixturePath = resolveFixture("simple");
+        const sourceGraph = new SourceGraph(fixturePath);
+
+        return expect(
+          () =>
+            sourceGraph.populate([
+              path.resolve(fixturePath, "test/bar.spec.js")
+            ]),
+          "to be fulfilled"
+        ).then(() => {
+          expect(
+            sourceGraph.query({
+              type: "relations",
+              to: path.resolve(fixturePath, "bar.js")
+            }),
+            "to satisfy",
+            [
+              {
+                from: path.resolve(fixturePath, "test/bar.spec.js"),
+                to: path.resolve(fixturePath, "bar.js")
+              }
+            ]
+          );
+        });
+      });
     });
 
-    it("should list incoming relations", async () => {
+    it("should find files required by tests", () => {
       const fixturePath = resolveFixture("simple");
       const sourceGraph = new SourceGraph(fixturePath);
 
-      // pass the list of test files mocha would run to populate
-      await sourceGraph.populate([
-        path.resolve(fixturePath, "test/bar.spec.js")
-      ]);
+      return expect(() => {
+        // pass the list of test files mocha would run to populate
+        return sourceGraph.populate([
+          path.resolve(fixturePath, "test/bar.spec.js")
+        ]);
+      }, "to be fulfilled").then(() => {
+        const file = sourceGraph.query({
+          type: "file",
+          path: path.resolve(fixturePath, "foo.js")
+        });
 
-      const file = sourceGraph.query({
-        type: "file",
-        path: path.resolve(fixturePath, "foo.js")
+        return expect(file.incomingRelations, "to satisfy", [
+          { from: path.resolve(fixturePath, "bar.js") }
+        ]);
       });
-
-      return expect(file.incomingRelations, "to satisfy", [
-        { from: path.resolve(fixturePath, "bar.js") }
-      ]);
     });
   });
 });

--- a/test/listDirtyFilesInGitRepo.spec.js
+++ b/test/listDirtyFilesInGitRepo.spec.js
@@ -12,7 +12,8 @@ describe("listDirtyFilesInGitRepo", () => {
   });
 
   it("should list dirty files", () => {
-    listDirtyFilesInGitRepo.getGitStatus = async () => "?? foo.js\n?? bar.js\n";
+    listDirtyFilesInGitRepo.getGitStatus = () =>
+      Promise.resolve("?? foo.js\n?? bar.js\n");
 
     return expect(
       () => listDirtyFilesInGitRepo("/fakeroot"),
@@ -22,8 +23,8 @@ describe("listDirtyFilesInGitRepo", () => {
   });
 
   it("should list dirty files when the first is modified", () => {
-    listDirtyFilesInGitRepo.getGitStatus = async () =>
-      " M package.json\n?? yarn.lock\n";
+    listDirtyFilesInGitRepo.getGitStatus = () =>
+      Promise.resolve(" M package.json\n?? yarn.lock\n");
 
     return expect(
       () => listDirtyFilesInGitRepo("/fakeroot"),

--- a/test/resolveRequire.spec.js
+++ b/test/resolveRequire.spec.js
@@ -11,39 +11,39 @@ describe("resolveRequire", () => {
 
   it("should throw NYI error when attempting to resolve a module", () => {
     return expect(
-      async () => resolveRequire(__filename, "unexpected"),
-      "to be rejected with",
+      () => resolveRequire(__filename, "unexpected"),
+      "to throw",
       "Module resolution not yet implemented"
     );
   });
 
-  it("should find foo.js when asking for ./foo", async () => {
+  it("should find foo.js when asking for ./foo", () => {
     return expect(
-      await resolveRequire(fixturesDir, "./foo"),
+      resolveRequire(fixturesDir, "./foo"),
       "to equal",
       path.resolve(fixturesDir, "foo.js")
     );
   });
 
-  it("should find bar/bar.js via bar/package.json when asking for ./bar", async () => {
+  it("should find bar/bar.js via bar/package.json when asking for ./bar", () => {
     return expect(
-      await resolveRequire(fixturesDir, "./bar"),
+      resolveRequire(fixturesDir, "./bar"),
       "to equal",
       path.resolve(fixturesDir, "bar/bar.js")
     );
   });
 
-  it("should find baz/index.js when asking for ./baz", async () => {
+  it("should find baz/index.js when asking for ./baz", () => {
     return expect(
-      await resolveRequire(fixturesDir, "./baz"),
+      resolveRequire(fixturesDir, "./baz"),
       "to equal",
       path.resolve(fixturesDir, "baz/index.js")
     );
   });
 
-  it("should find testdata.json when asking for testdata.json", async () => {
+  it("should find testdata.json when asking for testdata.json", () => {
     return expect(
-      await resolveRequire(fixturesDir, "./testdata.json"),
+      resolveRequire(fixturesDir, "./testdata.json"),
       "to equal",
       path.resolve(fixturesDir, "testdata.json")
     );


### PR DESCRIPTION
Should allow us to support the same node versions as mocha. Turned out that we didn't rely on it too much.

When merged (if it happens) we need to create an issue about removing the "engines.node" field in package.json, and do whatever mocha does to enforce supported node versions if anything.

RFR @alexjeffburke (merge at will if you approve)